### PR TITLE
Fix shaders for PC

### DIFF
--- a/Unity/Assets/Shaders/diva_opaque_outline_high.shader
+++ b/Unity/Assets/Shaders/diva_opaque_outline_high.shader
@@ -296,7 +296,7 @@ Shader "MCRS/Diva/Opaque_Outline_High" {
 				v2f o;
 
 				o.texcoord0 = v.texcoord0;
-				float4 screenvertex = UnityObjectToClipPos(v.position0);
+				float4 screenvertex = v.position0;
 				float4 projSpacePos;
 				projSpacePos.zw = screenvertex.zw;
 				float4 normaldir;
@@ -306,9 +306,10 @@ Shader "MCRS/Diva/Opaque_Outline_High" {
 				float4 scaledNormal = (((
 					(v.color0.x * _EdgeThickness)
 					* 0.00285) * normalize(
-					(UnityObjectToClipPos(float4(normaldir)))
+					(float4(normaldir))
 				)) * zbias);
 				projSpacePos.xy = (screenvertex.xy + scaledNormal.xy);
+				projSpacePos = UnityObjectToClipPos(projSpacePos); // while the original is correct on android gpu's this is typically the compilers job to fix
 				o.position0 = projSpacePos;
 				return o; 
 			}

--- a/Unity/Assets/Shaders/diva_trans_outline_high_alpha.shader
+++ b/Unity/Assets/Shaders/diva_trans_outline_high_alpha.shader
@@ -382,7 +382,7 @@ Shader "MCRS/Diva/Trans_Outline_High_Alpha" {
 				v2f o;
 
 				o.texcoord0 = v.texcoord0;
-				float4 screenvertex = UnityObjectToClipPos(v.position0);
+				float4 screenvertex = v.position0;
 				float4 projSpacePos;
 				projSpacePos.zw = screenvertex.zw;
 				float4 normaldir;
@@ -392,9 +392,10 @@ Shader "MCRS/Diva/Trans_Outline_High_Alpha" {
 				float4 scaledNormal = (((
 					(v.color0.x * _EdgeThickness)
 					* 0.00285) * normalize(
-					(UnityObjectToClipPos(float4(normaldir)))
+					(float4(normaldir))
 				)) * zbias);
 				projSpacePos.xy = (screenvertex.xy + scaledNormal.xy);
+				projSpacePos = UnityObjectToClipPos(projSpacePos);
 				o.position0 = projSpacePos;
 				return o; 
 			}


### PR DESCRIPTION
Normally is correct for Android devices, but typically unity compiler makes these fixes for you.